### PR TITLE
Landing page quick pass

### DIFF
--- a/app/index.pug
+++ b/app/index.pug
@@ -44,7 +44,7 @@ html.no-js(lang="en")
         .code-example
           != require("./examples/install.md")
 
-        .code-example
+        .code-example.has-run-button
           button(data-example="basic").run Run
           != require("./examples/basic.md")
 

--- a/app/site.styl
+++ b/app/site.styl
@@ -60,6 +60,9 @@ body
   position relative
   width 500px
 
+  &.has-run-button
+    padding-top 1.3em + 3em
+
   pre
     margin 0
     width 100%
@@ -68,11 +71,10 @@ body
     margin-top 1em
 
   button.run
-    background-color pink
+    background-color rgba(#000, .3)
     color white
-    font-variant small-caps
     margin 0
-    padding 0.3em 1em
+    padding .3em 1em
     position absolute
-    right 0
-    top 0
+    left 1.3em
+    top 1.3em

--- a/app/site.styl
+++ b/app/site.styl
@@ -60,6 +60,10 @@ body
   position relative
   width 500px
 
+  pre
+    margin 0
+    width 100%
+
   & + .code-example
     margin-top 1em
 

--- a/app/site.styl
+++ b/app/site.styl
@@ -51,7 +51,7 @@ body
 
 .github-star
   left 0
-  margin 0.35em
+  margin .35em
   position absolute
   top 0
 

--- a/app/site.styl
+++ b/app/site.styl
@@ -21,10 +21,12 @@ body
     font-size 2rem
     z-index -1
 
+    p
+      color saturate(lighten(landingPurple, 40%), 75%)
+
     .logo-text
       font-size 4.5rem
       font-weight bold
-      text-shadow -1px 1px 10px red, 3px -1px 10px green, -4px 3px 10px blue, 0px 2px 0px rgba(255, 255, 255, 0.6)
 
   &.pitch
     background-image linear-gradient(landingDeepBlue, lighten(landingDeepBlue, 5%))
@@ -38,11 +40,11 @@ body
     top 0
     opacity 0
     pointer-events none
-    transition opacity 100ms linear
+    transition opacity 300ms ease
     z-index -1
 
     &[data-rendered]
-      opacity 1
+      opacity .6
 
     .star
       transition opacity 500ms linear

--- a/app/site.styl
+++ b/app/site.styl
@@ -5,6 +5,9 @@ landingDeepBlue = rgb(13, 0, 33)
 landingBlue = rgb(43, 0, 107)
 landingPurple = rgb(156, 62, 163)
 
+body
+  user-select initial
+
 .slide
   align-items center
   justify-content center


### PR DESCRIPTION
hey @TeffenEllis this pr just has a little love for the landing page.

i was originally going to provide all of this as feedback in an issue but i found it faster to just make the changes.

aside from the commits within this pr, here are some other things i wanted to mention:

- i think the way we are sharing styles between the app and the landing page is confusing. the file name of "shared" is not sufficient imo to convey what ur going for. as one example, the landing page has `user-select none` on the body which is definitely bad practice. we may have had a reason to do this in the app but that's an app, not a document. (that being said we should allow user selection within the content pages of the app [the instructions pages], so that may need to be thought through as well).

- we should bring in our EagerIO/UI styles/colors for the code syntax highlighting or come up with our own for this project if we feel that UniversalEmbed deserves its own branding for some reason. (im leaning towards the former option.)

- i don't love the current position of the github stars iframe. i would prefer something more prominent like the other os project landing pages we based this template on.

its a great start! happy to help flesh out the content if ud like. lmk